### PR TITLE
Better (exteding) types

### DIFF
--- a/app/src/main/java/com/jacekmarchwicki/changesdetector/example/MainActivity.java
+++ b/app/src/main/java/com/jacekmarchwicki/changesdetector/example/MainActivity.java
@@ -77,7 +77,6 @@ public class MainActivity extends AppCompatActivity {
                     name.equals(data.name) &&
                     color == data.color;
         }
-
     }
 
     static class DataViewHolder implements ViewHolderManager {
@@ -133,9 +132,8 @@ public class MainActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(layoutManager);
 
         // Create universal adapter
-        final UniversalAdapter adapter = new UniversalAdapter(Collections.<ViewHolderManager>singletonList(new DataViewHolder()));
+        final UniversalAdapter adapter = new UniversalAdapter(Collections.singletonList(new DataViewHolder()));
         recyclerView.setAdapter(adapter);
-
 
         findViewById(R.id.main_activity_fab)
                 .setOnClickListener(new View.OnClickListener() {
@@ -159,7 +157,7 @@ public class MainActivity extends AppCompatActivity {
                 continue;
             }
             float realHue = hue % 1.0f;
-            final int color = Color.HSVToColor(255, new float[]{realHue * 360, 1.f, 0.5f});
+            final int color = Color.HSVToColor(255, new float[] {realHue * 360, 1.f, 0.5f});
             final String name = randomWithGaussianBoolean(random, 2.0) ? ("item" + i) : ("item" + i + " - changed");
             items.add(new Data(i, name, color));
         }

--- a/changes-detector/src/main/java/com/jacekmarchwicki/changesdetector/ChangesDetector.java
+++ b/changes-detector/src/main/java/com/jacekmarchwicki/changesdetector/ChangesDetector.java
@@ -24,7 +24,6 @@ import javax.annotation.Nonnull;
 
 import static com.jacekmarchwicki.changesdetector.internal.Preconditions.checkNotNull;
 
-
 /**
  * Detector for adapter items that can find what was changed and call recycler adapter methods
  *
@@ -96,7 +95,7 @@ public class ChangesDetector<T, H> {
      * @param force   true if you need to force all data reload
      */
     public void newData(@Nonnull ChangesAdapter adapter,
-                        @Nonnull List<T> values,
+                        @Nonnull List<? extends T> values,
                         boolean force) {
         checkNotNull(adapter);
         checkNotNull(values);
@@ -156,7 +155,6 @@ public class ChangesDetector<T, H> {
         mItems = list;
     }
 
-
     private int lastPosition;
     private int count;
     private int lastAction;
@@ -195,7 +193,7 @@ public class ChangesDetector<T, H> {
     }
 
     @Nonnull
-    private H[] apply(@Nonnull List<T> values) {
+    private H[] apply(@Nonnull List<? extends T> values) {
         @SuppressWarnings("unchecked")
         final H[] result = (H[]) new Object[values.size()];
         for (int i = 0; i < values.size(); i++) {
@@ -205,5 +203,4 @@ public class ChangesDetector<T, H> {
 
         return result;
     }
-
 }

--- a/universal-adapter-rx/src/main/java/com/jacekmarchwicki/universaladapter/rx/RxUniversalAdapter.java
+++ b/universal-adapter-rx/src/main/java/com/jacekmarchwicki/universaladapter/rx/RxUniversalAdapter.java
@@ -32,9 +32,9 @@ import rx.functions.Action1;
  * Universal adapter for {@link RecyclerView} that will automatically detect changes designed for
  * rx-java
  */
-public class RxUniversalAdapter extends UniversalAdapter implements Action1<List<BaseAdapterItem>> {
+public class RxUniversalAdapter extends UniversalAdapter implements Action1<List<? extends BaseAdapterItem>> {
 
-    public RxUniversalAdapter(@Nonnull List<ViewHolderManager> managers) {
+    public RxUniversalAdapter(@Nonnull List<? extends ViewHolderManager> managers) {
         super(managers);
     }
 

--- a/universal-adapter/src/main/java/com/jacekmarchwicki/universaladapter/UniversalAdapter.java
+++ b/universal-adapter/src/main/java/com/jacekmarchwicki/universaladapter/UniversalAdapter.java
@@ -36,9 +36,9 @@ public class UniversalAdapter extends RecyclerView.Adapter<ViewHolderManager.Bas
     private final ChangesDetector<BaseAdapterItem, BaseAdapterItem> changesDetector =
             new ChangesDetector<>(new SimpleDetector<BaseAdapterItem>());
     @Nonnull
-    private final List<ViewHolderManager> managers;
+    private final List<? extends ViewHolderManager> managers;
     @Nonnull
-    private List<BaseAdapterItem> items = Collections.emptyList();
+    private List<? extends BaseAdapterItem> items = Collections.emptyList();
 
     /**
      * Usage:
@@ -132,11 +132,11 @@ public class UniversalAdapter extends RecyclerView.Adapter<ViewHolderManager.Bas
      *
      * @param managers for inflating views
      */
-    public UniversalAdapter(@Nonnull List<ViewHolderManager> managers) {
+    public UniversalAdapter(@Nonnull List<? extends ViewHolderManager> managers) {
         this.managers = managers;
     }
 
-    public void call(@Nonnull List<BaseAdapterItem> baseAdapterItems) {
+    public void call(@Nonnull List<? extends BaseAdapterItem> baseAdapterItems) {
         items = baseAdapterItems;
         changesDetector.newData(this, items, false);
     }
@@ -184,7 +184,7 @@ public class UniversalAdapter extends RecyclerView.Adapter<ViewHolderManager.Bas
      * @param position of item on the list
      * @return item at position
      * @throws IndexOutOfBoundsException if the position is out of range
-     *    (<tt>position &lt; 0 || index &gt;= getItemCount()</tt>)
+     *                                   (<tt>position &lt; 0 || index &gt;= getItemCount()</tt>)
      */
     @Nonnull
     public BaseAdapterItem getItemAtPosition(int position) {


### PR DESCRIPTION
You may use now

```java
new UniversalAdapter(Collections.singletonList(new DataViewHolder()));
```

instead of

```java
new UniversalAdapter(Collections.<ViewHolderManager>singletonList(new DataViewHolder()));
```

The same with `public void call(@Nonnull List<? extends BaseAdapterItem> baseAdapterItems)` method.